### PR TITLE
OPS-503: add system chargeback category

### DIFF
--- a/proto/fraudbusters.thrift
+++ b/proto/fraudbusters.thrift
@@ -217,6 +217,7 @@ enum ChargebackCategory {
     dispute
     authorisation
     processing_error
+    system_set
 }
 
 struct Chargeback {


### PR DESCRIPTION
Из того что я понял, в этот протокол тоже надо добавить новый тип категории чарджбека, потому что fraudbusters-mg-connector должен как-то маппить новый тип. Затем fraudbusters должен будет сохранить это к себе в базу для дальнейших запросов с агрегацией.